### PR TITLE
Change target frameworks to .Net 8 and .NET Standard 2.1.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,19 +15,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core 2.1
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v4
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '2.1.x'
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '8.0.x'
     - name: Fix Windows VM bug
       shell: bash
       if: matrix.os == 'windows-latest'
@@ -44,7 +36,7 @@ jobs:
       run: dotnet pack -c Release
     - name: Publish artifact
       if: matrix.os == 'ubuntu-latest'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: nupkg
         path: '**/*.nupkg'

--- a/src/ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher/ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher.csproj
+++ b/src/ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher/ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher.csproj
@@ -1,24 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher</AssemblyName>
     <PackageId>ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher</PackageId>
     <Authors>Scott Brady</Authors>
     <Description>ASP.NET Core Identity IPasswordHasher implementation using Argon2</Description>
-    <Copyright>Copyright (c) 2020 Scott Brady</Copyright>
+    <Copyright>Copyright (c) 2025 Scott Brady</Copyright>
     <PackageTags>aspnetcore;identity;Argon2;password;hashing;hash;security</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/scottbrady91/ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>true</IncludeSymbols>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageVersion>1.4.0</PackageVersion>
-    <PackageReleaseNotes>Fixed issue with null-terminated strings.</PackageReleaseNotes>
+    <PackageVersion>2.0.0</PackageVersion>
+    <PackageReleaseNotes>Migrated to .NET 8 and updated dependencies.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="2.1.0" />
-    <PackageReference Include="Sodium.Core" Version="1.2.3" />
+    <PackageReference Include="Sodium.Core" Version="1.4.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="[8.0.0,9.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="[3.1.0,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher.Tests/ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher.Tests.csproj
+++ b/test/ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher.Tests/ScottBrady91.AspNetCore.Identity.Argon2PasswordHasher.Tests.csproj
@@ -1,29 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.21" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="2.1.6" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.1.12" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes
- Updated target frameworks to `net8.0` and `netstandard2.1` (multi-targeting)
- Updated `Microsoft.Extensions.Identity.Core` to version 8.0.x for net8.0 target
- Updated `Sodium.Core` to version 1.4.0
- Used version ranges to allow consumers flexibility in dependency versions:
  - net8.0: `[8.0.0,9.0.0)` for Identity.Core
  - netstandard2.1: `[3.1.0,9.0.0)` for Identity.Core (or `[3.1.0,)` if preferred)
- Updated test project to .NET 8 with latest test package versions
- Bumped package version to 2.0.0 (breaking change due to minimum framework requirements)

## Compatibility
- **net8.0 consumers**: Get optimized .NET 8 assembly
- **Older framework consumers** (NET Core 3.1+, NET 5/6/7): Use netstandard2.1 assembly with appropriate Identity.Core version

## Testing
- All 17 tests pass on .NET 8
- Both target frameworks build successfully without warnings

## Breaking Changes
- Minimum framework requirement increased from .NET Standard 2.0 to .NET Standard 2.1 / .NET 8
- Consumers on .NET Framework or .NET Core 2.x will need to use the previous version

I know that .Net 10 is almost out, so if you accept this pull request, I'll be happy to provide another one for .Net 10.

Thank you!